### PR TITLE
Suggestion for exposing the device specific APIs

### DIFF
--- a/src/bladerf.rs
+++ b/src/bladerf.rs
@@ -60,7 +60,7 @@ impl<D: HardwareVariant> Drop for BladeRF<D> {
     }
 }
 
-impl<D: HardwareVariant> BladeRF<D> {
+impl BladeRF<Unknown> {
     pub fn open_first() -> Result<BladeRF<Unknown>> {
         log::info!("Opening first bladerf");
         let mut device = std::ptr::null_mut();
@@ -107,7 +107,9 @@ impl<D: HardwareVariant> BladeRF<D> {
             _p: PhantomData,
         })
     }
+}
 
+impl<D: HardwareVariant> BladeRF<D> {
     pub fn info(&self) -> Result<DevInfo> {
         let mut info = bladerf_devinfo {
             backend: 0,
@@ -1116,7 +1118,7 @@ mod tests {
     fn test_open() {
         let _m = DEV_MUTEX.lock();
 
-        let _device = <BladeRF>::open_first().unwrap();
+        let _device = BladeRF::open_first().unwrap();
     }
 
     #[test]
@@ -1125,14 +1127,14 @@ mod tests {
 
         let devices = crate::get_device_list().unwrap();
         assert!(!devices.is_empty());
-        let _device = BladeRF::<Unknown>::open_with_devinfo(&devices[0]).unwrap();
+        let _device = BladeRF::open_with_devinfo(&devices[0]).unwrap();
     }
 
     #[test]
     fn test_get_fw_version() {
         let _m = DEV_MUTEX.lock();
 
-        let device = BladeRF::<Unknown>::open_first().unwrap();
+        let device = BladeRF::open_first().unwrap();
 
         let version = device.firmware_version().unwrap();
         println!("FW Version {:?}", version);
@@ -1142,7 +1144,7 @@ mod tests {
     fn test_get_fpga_version() {
         let _m = DEV_MUTEX.lock();
 
-        let device = BladeRF::<Unknown>::open_first().unwrap();
+        let device = BladeRF::open_first().unwrap();
 
         let version = device.fpga_version().unwrap();
         println!("FPGA Version {:?}", version);
@@ -1152,7 +1154,7 @@ mod tests {
     fn test_get_serial() {
         let _m = DEV_MUTEX.lock();
 
-        let device = BladeRF::<Unknown>::open_first().unwrap();
+        let device = BladeRF::open_first().unwrap();
 
         let serial = device.get_serial().unwrap();
         println!("Serial: {:?}", serial);
@@ -1163,7 +1165,7 @@ mod tests {
     fn test_fpga_loaded() {
         let _m = DEV_MUTEX.lock();
 
-        let device = BladeRF::<Unknown>::open_first().unwrap();
+        let device = BladeRF::open_first().unwrap();
 
         let loaded = device.is_fpga_configured().unwrap();
         assert!(loaded);
@@ -1173,7 +1175,7 @@ mod tests {
     fn test_loopback_modes() {
         let _m = DEV_MUTEX.lock();
 
-        let device = BladeRF::<Unknown>::open_first().unwrap();
+        let device = BladeRF::open_first().unwrap();
 
         // Check initial is none
         let loopback = device.get_loopback().unwrap();
@@ -1195,7 +1197,7 @@ mod tests {
     fn test_set_freq() {
         let _m = DEV_MUTEX.lock();
 
-        let device = BladeRF::<Unknown>::open_first().unwrap();
+        let device = BladeRF::open_first().unwrap();
 
         let freq: u64 = 915000000;
 
@@ -1210,7 +1212,7 @@ mod tests {
     fn test_set_sampling() {
         let _m = DEV_MUTEX.lock();
 
-        let device = BladeRF::<Unknown>::open_first().unwrap();
+        let device = BladeRF::open_first().unwrap();
 
         let desired = Sampling::Internal;
         // Set and check frequency
@@ -1230,7 +1232,7 @@ mod tests {
     #[test]
     // This should be removed.
     fn test_bladerf1_ex() {
-        let dev = BladeRF::<Unknown>::open_first().unwrap();
+        let dev = BladeRF::open_first().unwrap();
         let newdev: BladeRF<BladeRf1> = dev.try_into().unwrap();
         newdev.set_txvga2(-20).unwrap();
         let _fwv = newdev.firmware_version().unwrap();

--- a/src/bladerf.rs
+++ b/src/bladerf.rs
@@ -35,7 +35,7 @@ pub struct Unknown {}
 impl HardwareVariant for Unknown {}
 
 /// BladeRF device object
-pub struct BladeRF<D: HardwareVariant> {
+pub struct BladeRF<D: HardwareVariant = Unknown> {
     device: *mut bladerf,
     enabled_modules: Mutex<EnumMap<Channel, bool>>,
     format_sync: RwLock<Option<Format>>,
@@ -1116,7 +1116,7 @@ mod tests {
     fn test_open() {
         let _m = DEV_MUTEX.lock();
 
-        let _device = BladeRF::<Unknown>::open_first().unwrap();
+        let _device = <BladeRF>::open_first().unwrap();
     }
 
     #[test]

--- a/src/bladerf.rs
+++ b/src/bladerf.rs
@@ -1107,7 +1107,12 @@ impl TryFrom<BladeRF<Unknown>> for BladeRF<BladeRf1> {
         if value.get_board_name() == "bladerf1" {
             let dev_to_move = ManuallyDrop::new(value);
 
-            // Use `std::ptr::read` to safely move non-Copy fields out of the ManuallyDrop wrapper
+            // Use `std::ptr::read` to move non-Copy fields out of the ManuallyDrop wrapper
+            // SAFETY:
+            // 1. Came from a valid object, so each field is valid for reads
+            // 2. Came from a valid object, so each field is guaranteed to be aligned
+            // 3. Came from a valid object, so each field is properly initialized
+            // 4. Each field is read exactly once and then not dropped, therefore no double objects are created
             let device = unsafe { std::ptr::read(&dev_to_move.device) };
             let enabled_modules = unsafe { std::ptr::read(&dev_to_move.enabled_modules) };
             let format_sync = unsafe { std::ptr::read(&dev_to_move.format_sync) };

--- a/src/bladerf.rs
+++ b/src/bladerf.rs
@@ -339,26 +339,6 @@ impl<D: HardwareVariant> BladeRF<D> {
         Ok(Range::from(range))
     }
 
-    pub fn set_lpf_mode(&self, channel: Channel, lpf_mode: LPFMode) -> Result<()> {
-        let res = unsafe {
-            bladerf_set_lpf_mode(
-                self.device,
-                channel as bladerf_channel,
-                lpf_mode as bladerf_lpf_mode,
-            )
-        };
-        check_res!(res);
-        Ok(())
-    }
-
-    pub fn get_lpf_mode(&self, channel: Channel) -> Result<LPFMode> {
-        let mut lpf_mode = bladerf_lpf_mode_BLADERF_LPF_NORMAL;
-        let res =
-            unsafe { bladerf_get_lpf_mode(self.device, channel as bladerf_channel, &mut lpf_mode) };
-        check_res!(res);
-        LPFMode::try_from(lpf_mode)
-    }
-
     /// Set frequency band
     pub fn select_band(&self, channel: Channel, frequency: u64) -> Result<()> {
         let res =
@@ -499,7 +479,6 @@ impl<D: HardwareVariant> BladeRF<D> {
         }
     }
 
-    // SMB Clock Port Control
     // **Gain Control Functions**
 
     /// Set overall system gain
@@ -1046,6 +1025,78 @@ impl BladeRF<BladeRf1> {
         let res = unsafe { bladerf_get_sampling(self.device, &mut sampling) };
         check_res!(res);
         Sampling::try_from(sampling)
+    }
+
+    pub fn set_lpf_mode(&self, channel: Channel, lpf_mode: LPFMode) -> Result<()> {
+        let res = unsafe {
+            bladerf_set_lpf_mode(
+                self.device,
+                channel as bladerf_channel,
+                lpf_mode as bladerf_lpf_mode,
+            )
+        };
+        check_res!(res);
+        Ok(())
+    }
+
+    pub fn get_lpf_mode(&self, channel: Channel) -> Result<LPFMode> {
+        let mut lpf_mode = bladerf_lpf_mode_BLADERF_LPF_NORMAL;
+        let res =
+            unsafe { bladerf_get_lpf_mode(self.device, channel as bladerf_channel, &mut lpf_mode) };
+        check_res!(res);
+        LPFMode::try_from(lpf_mode)
+    }
+
+    pub fn set_smb_mode(&self, mode: SmbMode) -> Result<()> {
+        let res = unsafe { bladerf_set_smb_mode(self.device, mode as bladerf_smb_mode) };
+        check_res!(res);
+        Ok(())
+    }
+
+    pub fn get_smb_mode(&self) -> Result<SmbMode> {
+        let mut mode = bladerf_smb_mode_BLADERF_SMB_MODE_INVALID;
+        let res = unsafe { bladerf_get_smb_mode(self.device, &mut mode) };
+        check_res!(res);
+        SmbMode::try_from(mode)
+    }
+
+    // TODO: Is it an issue that the rate passed into the c abi call requires a mutable pointer? does it actually get mutated?
+    pub fn set_rational_smb_frequency(&self, frequency: RationalRate) -> Result<RationalRate> {
+        let mut actual_freq = bladerf_rational_rate {
+            integer: 0,
+            num: 0,
+            den: 0,
+        };
+        let res = unsafe {
+            bladerf_set_rational_smb_frequency(self.device, &mut frequency.into(), &mut actual_freq)
+        };
+        check_res!(res);
+        Ok(actual_freq.into())
+    }
+
+    pub fn get_rational_smb_frequency(&self) -> Result<RationalRate> {
+        let mut freq = bladerf_rational_rate {
+            integer: 0,
+            num: 0,
+            den: 0,
+        };
+        let res = unsafe { bladerf_get_rational_smb_frequency(self.device, &mut freq) };
+        check_res!(res);
+        Ok(freq.into())
+    }
+
+    pub fn set_smb_frequency(&self, frequency: u32) -> Result<u32> {
+        let mut actual_freq = 0;
+        let res = unsafe { bladerf_set_smb_frequency(self.device, frequency, &mut actual_freq) };
+        check_res!(res);
+        Ok(actual_freq)
+    }
+
+    pub fn get_smb_frequency(&self) -> Result<u32> {
+        let mut freq = 0;
+        let res = unsafe { bladerf_get_smb_frequency(self.device, &mut freq) };
+        check_res!(res);
+        Ok(freq)
     }
 }
 

--- a/src/bladerf.rs
+++ b/src/bladerf.rs
@@ -22,30 +22,30 @@ macro_rules! check_res {
 pub const FPGA_BITSTREAM_VAR_NAME: &str = "BLADERF_RS_FPGA_BITSTREAM_PATH";
 pub const DEFAULT_FPGA_BITSTREAM: &[u8] = include_bytes!(env!("BLADERF_RS_FPGA_BITSTREAM_PATH"));
 
-trait DeviceType {}
+trait HardwareVariant {}
 
 pub struct BladeRf1 {}
 
-impl DeviceType for BladeRf1 {}
+impl HardwareVariant for BladeRf1 {}
 
 pub struct BladeRf2 {}
-impl DeviceType for BladeRf2 {}
+impl HardwareVariant for BladeRf2 {}
 
 pub struct Unknown {}
-impl DeviceType for Unknown {}
+impl HardwareVariant for Unknown {}
 
 /// BladeRF device object
-pub struct BladeRF<D: DeviceType> {
+pub struct BladeRF<D: HardwareVariant> {
     device: *mut bladerf,
     enabled_modules: Mutex<EnumMap<Channel, bool>>,
     format_sync: RwLock<Option<Format>>,
     _p: PhantomData<D>,
 }
 
-unsafe impl<D: DeviceType> Send for BladeRF<D> {}
-unsafe impl<D: DeviceType> Sync for BladeRF<D> {}
+unsafe impl<D: HardwareVariant> Send for BladeRF<D> {}
+unsafe impl<D: HardwareVariant> Sync for BladeRF<D> {}
 
-impl<D: DeviceType> Drop for BladeRF<D> {
+impl<D: HardwareVariant> Drop for BladeRF<D> {
     fn drop(&mut self) {
         let enabled_modules = *self.enabled_modules.get_mut();
         for (channel, enabled) in enabled_modules {
@@ -60,7 +60,7 @@ impl<D: DeviceType> Drop for BladeRF<D> {
     }
 }
 
-impl<D: DeviceType> BladeRF<D> {
+impl<D: HardwareVariant> BladeRF<D> {
     pub fn open_first() -> Result<BladeRF<Unknown>> {
         log::info!("Opening first bladerf");
         let mut device = std::ptr::null_mut();

--- a/src/bladerf.rs
+++ b/src/bladerf.rs
@@ -287,19 +287,6 @@ impl<D: HardwareVariant> BladeRF<D> {
         Ok(Range::from(range))
     }
 
-    pub fn set_sampling(&self, sampling: Sampling) -> Result<()> {
-        let res = unsafe { bladerf_set_sampling(self.device, sampling as bladerf_sampling) };
-        check_res!(res);
-        Ok(())
-    }
-
-    pub fn get_sampling(&self) -> Result<Sampling> {
-        let mut sampling = bladerf_sampling_BLADERF_SAMPLING_UNKNOWN;
-        let res = unsafe { bladerf_get_sampling(self.device, &mut sampling) };
-        check_res!(res);
-        Sampling::try_from(sampling)
-    }
-
     pub fn set_rx_mux(&self, mux: RxMux) -> Result<()> {
         let res = unsafe { bladerf_set_rx_mux(self.device, mux as bladerf_rx_mux) };
         check_res!(res);
@@ -1047,6 +1034,19 @@ impl BladeRF<BladeRf1> {
         check_res!(res);
         Ok(())
     }
+
+    pub fn set_sampling(&self, sampling: Sampling) -> Result<()> {
+        let res = unsafe { bladerf_set_sampling(self.device, sampling as bladerf_sampling) };
+        check_res!(res);
+        Ok(())
+    }
+
+    pub fn get_sampling(&self) -> Result<Sampling> {
+        let mut sampling = bladerf_sampling_BLADERF_SAMPLING_UNKNOWN;
+        let res = unsafe { bladerf_get_sampling(self.device, &mut sampling) };
+        check_res!(res);
+        Sampling::try_from(sampling)
+    }
 }
 
 /// TODO: Safety Comment
@@ -1209,24 +1209,20 @@ mod tests {
     }
 
     #[test]
-    fn test_set_sampling() {
+    #[ignore = "bladerf1 specific test"]
+    fn test_bladerf1_set_sampling() -> Result<()> {
         let _m = DEV_MUTEX.lock();
 
-        let device = BladeRF::open_first().unwrap();
+        let device: BladeRF<BladeRf1> = BladeRF::open_first()?.try_into()?;
 
         let desired = Sampling::Internal;
-        // Set and check frequency
-        if let Err(e) = device.set_sampling(desired) {
-            if e != Error::Unsupported {
-                panic!("unexpected error of value when calling set_sampling {e:?}",);
-            } else {
-                return;
-            }
-        };
+
+        device.set_sampling(desired)?;
 
         let actual = device.get_sampling().unwrap();
 
         assert_eq!(desired, actual);
+        Ok(())
     }
 
     #[test]

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -63,3 +63,6 @@ pub use trigger::*;
 
 mod layout;
 pub use layout::*;
+
+mod smb_mode;
+pub use smb_mode::*;

--- a/src/types/rational_rate.rs
+++ b/src/types/rational_rate.rs
@@ -1,5 +1,6 @@
 use crate::sys::*;
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct RationalRate {
     /// Integer portion
     pub integer: u64,
@@ -15,6 +16,16 @@ impl From<bladerf_rational_rate> for RationalRate {
             integer: rate.integer,
             num: rate.num,
             den: rate.den,
+        }
+    }
+}
+
+impl From<RationalRate> for bladerf_rational_rate {
+    fn from(value: RationalRate) -> Self {
+        bladerf_rational_rate {
+            integer: value.integer,
+            num: value.num,
+            den: value.den,
         }
     }
 }

--- a/src/types/smb_mode.rs
+++ b/src/types/smb_mode.rs
@@ -1,0 +1,24 @@
+use strum::FromRepr;
+
+use crate::{sys::*, Error, Result};
+
+pub const SMB_FREQUENCY_MAX: u32 = BLADERF_SMB_FREQUENCY_MAX;
+pub const SMB_FREQUENCY_MIN: u32 = BLADERF_SMB_FREQUENCY_MIN;
+
+#[derive(Copy, Clone, Debug, FromRepr, PartialEq, Eq)]
+#[repr(i32)]
+pub enum SmbMode {
+    Invalid = bladerf_smb_mode_BLADERF_SMB_MODE_INVALID,
+    Disabled = bladerf_smb_mode_BLADERF_SMB_MODE_DISABLED,
+    Output = bladerf_smb_mode_BLADERF_SMB_MODE_OUTPUT,
+    Input = bladerf_smb_mode_BLADERF_SMB_MODE_INPUT,
+    Unavailable = bladerf_smb_mode_BLADERF_SMB_MODE_UNAVAILBLE,
+}
+
+impl TryFrom<bladerf_smb_mode> for SmbMode {
+    type Error = Error;
+
+    fn try_from(value: bladerf_smb_mode) -> Result<Self> {
+        Self::from_repr(value).ok_or_else(|| Error::msg(format!("Invalid Sampling value: {value}")))
+    }
+}


### PR DESCRIPTION
WIP to expose the device specific APIs.

Example:
```rust
        let dev = BladeRF::<Unknown>::open_first().unwrap();
        let brf1_dev: BladeRF<BladeRf1> = dev.try_into().unwrap();

        // This would not be valid if the type was BladeRF<Unknown>
        brf1_dev.set_txvga2(-20).unwrap();

        // This is still valid since this function is implemented on BladeRF<D: DeviceType>
        let _fwv = brf1_dev.firmware_version().unwrap();
```

I am opening this to get some feedback.    
    