### PR TITLE
Add device speed

### DIFF
--- a/examples/firmware_update.rs
+++ b/examples/firmware_update.rs
@@ -42,7 +42,7 @@ pub fn main() -> anyhow::Result<()> {
         };
 
         if let Ok(current) = dev
-            .firmware_version()
+            .get_firmware_version()
             .map_err(|e| println!("Failed to obtain firmware version: {e:?}"))
         {
             if current == desired_firmware_version {
@@ -80,7 +80,7 @@ pub fn main() -> anyhow::Result<()> {
                         continue;
                     };
                     let Ok(new_version) = dev
-                        .firmware_version()
+                        .get_firmware_version()
                         .map_err(|e| println!("Failed to read firmware version: {e:?}"))
                     else {
                         continue;

--- a/examples/info.rs
+++ b/examples/info.rs
@@ -20,6 +20,11 @@ pub fn main() -> anyhow::Result<()> {
 
         let dev = d.open().context("Failed to open device")?;
 
+        let speed = dev
+            .get_device_speed()
+            .context("Failed to get device speed")?;
+        println!("Speed: {speed:?}");
+
         dev.load_fpga_from_env()
             .context("Failed to load FPGA bitstream")?;
 
@@ -48,12 +53,12 @@ pub fn main() -> anyhow::Result<()> {
 
 fn print_device_info(dev: &BladeRfAny) -> anyhow::Result<()> {
     let fw_version = dev
-        .firmware_version()
+        .get_firmware_version()
         .context("Failed to retrieve firmware version")?;
     println!("  Firmware Version: {fw_version}");
 
     let fpga_version = dev
-        .fpga_version()
+        .get_fpga_version()
         .context("Failed to retrieve FPGA version")?;
     println!("  FPGA Version: {fpga_version}");
 

--- a/src/bladerf.rs
+++ b/src/bladerf.rs
@@ -163,7 +163,7 @@ pub trait BladeRF: Sized + Drop {
         Ok(serial_str.to_string())
     }
 
-    fn device_speed(&self) -> Result<DeviceSpeed> {
+    fn get_device_speed(&self) -> Result<DeviceSpeed> {
         let speed = unsafe { bladerf_device_speed(self.get_device_ptr()) };
         speed.try_into()
     }
@@ -175,7 +175,7 @@ pub trait BladeRF: Sized + Drop {
         fpga_size.try_into()
     }
 
-    fn firmware_version(&self) -> Result<Version> {
+    fn get_firmware_version(&self) -> Result<Version> {
         let mut version = bladerf_version {
             major: 0,
             minor: 0,
@@ -201,7 +201,7 @@ pub trait BladeRF: Sized + Drop {
         }
     }
 
-    fn fpga_version(&self) -> Result<Version> {
+    fn get_fpga_version(&self) -> Result<Version> {
         let mut version = bladerf_version {
             major: 0,
             minor: 0,

--- a/src/bladerf.rs
+++ b/src/bladerf.rs
@@ -163,6 +163,11 @@ pub trait BladeRF: Sized + Drop {
         Ok(serial_str.to_string())
     }
 
+    fn device_speed(&self) -> Result<DeviceSpeed> {
+        let speed = unsafe { bladerf_device_speed(self.get_device_ptr()) };
+        speed.try_into()
+    }
+
     fn get_fpga_size(&self) -> Result<FpgaSize> {
         let mut fpga_size: bladerf_fpga_size = bladerf_fpga_size_BLADERF_FPGA_UNKNOWN;
         let res = unsafe { bladerf_get_fpga_size(self.get_device_ptr(), &mut fpga_size) };

--- a/src/types/device_speed.rs
+++ b/src/types/device_speed.rs
@@ -1,0 +1,28 @@
+// Allow clippy::unnecessary_cast since the cast is needed for when bindgen runs on windows. The enum variants get cast to i32 on windows.
+#![allow(clippy::unnecessary_cast)]
+use strum::FromRepr;
+
+use crate::{sys::*, Error, Result};
+
+#[derive(Copy, Clone, Debug, FromRepr, PartialEq, Eq)]
+#[repr(u32)]
+pub enum DeviceSpeed {
+    Unknown = bladerf_dev_speed_BLADERF_DEVICE_SPEED_UNKNOWN as u32,
+    High = bladerf_dev_speed_BLADERF_DEVICE_SPEED_HIGH as u32,
+    Super = bladerf_dev_speed_BLADERF_DEVICE_SPEED_SUPER as u32,
+}
+
+impl From<DeviceSpeed> for bladerf_dev_speed {
+    fn from(dir: DeviceSpeed) -> Self {
+        dir as bladerf_dev_speed
+    }
+}
+
+impl TryFrom<bladerf_fpga_size> for DeviceSpeed {
+    type Error = Error;
+
+    fn try_from(value: bladerf_dev_speed) -> Result<Self> {
+        Self::from_repr(value as u32)
+            .ok_or_else(|| Error::msg(format!("Invalid Dev Speed discriminant: {value}")))
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -72,3 +72,6 @@ pub use expansion_module::*;
 
 mod fpga_size;
 pub use fpga_size::*;
+
+mod device_speed;
+pub use device_speed::*;


### PR DESCRIPTION
- Adds device speed for determining speed of USB connection (can be lower than expected if using the wrong port / bad cable)
- Prefixes `firmware_version` and `fpga_version` to start with `get_XXX` to match the other functions