### PR TITLE
Rename SyncConfig to StreamConfig

### DIFF
--- a/examples/ook.rs
+++ b/examples/ook.rs
@@ -10,7 +10,7 @@ use std::{
 
 use anyhow::Context;
 use bladerf::{
-    BladeRF, Channel, ChannelLayoutRx, ChannelLayoutTx, ComplexI16, RxChannel, SyncConfig,
+    BladeRF, Channel, ChannelLayoutRx, ChannelLayoutTx, ComplexI16, RxChannel, StreamConfig,
     TxChannel,
 };
 use crossterm::{
@@ -94,7 +94,7 @@ fn rx(
     let mut sample_buffer = Vec::new();
     let mut bits = Vec::new();
 
-    let config = SyncConfig::new(
+    let config = StreamConfig::new(
         c.num_buffers,
         c.buffer_size,
         c.num_transfers,
@@ -238,7 +238,7 @@ fn tx(
     let mut sample_count = 0;
     let mut bytes = 0;
 
-    let config = SyncConfig::new(
+    let config = StreamConfig::new(
         c.num_buffers,
         c.buffer_size,
         c.num_transfers,

--- a/examples/rx_file.rs
+++ b/examples/rx_file.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Ok};
-use bladerf::{BladeRF, BladeRfAny, ChannelLayoutRx, ComplexI16, RxChannel, SyncConfig};
+use bladerf::{BladeRF, BladeRfAny, ChannelLayoutRx, ComplexI16, RxChannel, StreamConfig};
 use indicatif::{ProgressBar, ProgressStyle};
 use num_complex::Complex;
 use std::{
@@ -105,7 +105,7 @@ fn main() -> anyhow::Result<()> {
 
     log::debug!("Sample rate set to {}", args.samplerate);
 
-    let config = SyncConfig::new(16, SAMPLES_PER_BLOCK, 8, Duration::from_secs(3))
+    let config = StreamConfig::new(16, SAMPLES_PER_BLOCK, 8, Duration::from_secs(3))
         .with_context(|| "Cannot Create Sync Config")?;
     let layout = ChannelLayoutRx::SISO(channel);
     let reciever = dev

--- a/src/bladerf.rs
+++ b/src/bladerf.rs
@@ -1,4 +1,4 @@
-use crate::{error::*, sys::*, types::*, RxSyncStream, SyncConfig, TxSyncStream};
+use crate::{error::*, sys::*, types::*, RxSyncStream, StreamConfig, TxSyncStream};
 use ffi::{c_char, CStr, CString};
 use path::Path;
 use std::{mem::ManuallyDrop, *};
@@ -67,7 +67,7 @@ impl BladeRfAny {
 
     pub fn tx_streamer<T: SampleFormat>(
         &self,
-        config: SyncConfig,
+        config: StreamConfig,
         layout: ChannelLayoutTx,
     ) -> Result<TxSyncStream<&Self, T, Self>> {
         // TODO: Decide Ordering
@@ -83,7 +83,7 @@ impl BladeRfAny {
 
     pub fn rx_streamer<T: SampleFormat>(
         &self,
-        config: SyncConfig,
+        config: StreamConfig,
         layout: ChannelLayoutRx,
     ) -> Result<RxSyncStream<&Self, T, BladeRfAny>> {
         // TODO: Decide Ordering
@@ -315,7 +315,7 @@ pub trait BladeRF: Sized + Drop {
     #[doc(hidden)]
     unsafe fn set_sync_config<T: SampleFormat>(
         &self,
-        config: &SyncConfig,
+        config: &StreamConfig,
         layout: ChannelLayout,
     ) -> Result<()> {
         let res = unsafe {

--- a/src/bladerf1.rs
+++ b/src/bladerf1.rs
@@ -1,5 +1,5 @@
 use crate::expansion_boards::Xb200;
-use crate::streamers::{RxSyncStream, SyncConfig, TxSyncStream};
+use crate::streamers::{RxSyncStream, StreamConfig, TxSyncStream};
 use crate::{error::*, sys::*, types::*, BladeRF, BladeRfAny};
 use mem::ManuallyDrop;
 use std::*;
@@ -109,7 +109,7 @@ impl BladeRf1 {
 
     pub fn tx_streamer<T: SampleFormat>(
         &self,
-        config: SyncConfig,
+        config: StreamConfig,
     ) -> Result<TxSyncStream<&Self, T, BladeRf1>> {
         // TODO: Decide Ordering
         self.tx_stream_configured
@@ -124,7 +124,7 @@ impl BladeRf1 {
 
     pub fn rx_streamer<T: SampleFormat>(
         &self,
-        config: SyncConfig,
+        config: StreamConfig,
     ) -> Result<RxSyncStream<&Self, T, BladeRf1>> {
         // TODO: Decide Ordering
         self.rx_stream_configured

--- a/src/bladerf2.rs
+++ b/src/bladerf2.rs
@@ -1,4 +1,4 @@
-use crate::streamers::{RxSyncStream, SyncConfig, TxSyncStream};
+use crate::streamers::{RxSyncStream, StreamConfig, TxSyncStream};
 use crate::{error::*, sys::*, types::*, BladeRF, BladeRfAny};
 use mem::ManuallyDrop;
 use std::*;
@@ -30,7 +30,7 @@ impl BladeRf2 {
 
     pub fn tx_streamer<T: SampleFormat>(
         &self,
-        config: SyncConfig,
+        config: StreamConfig,
         layout: ChannelLayoutTx,
     ) -> Result<TxSyncStream<&Self, T, BladeRf2>> {
         // TODO: Decide Ordering
@@ -46,7 +46,7 @@ impl BladeRf2 {
 
     pub fn rx_streamer<T: SampleFormat>(
         &self,
-        config: SyncConfig,
+        config: StreamConfig,
         layout: ChannelLayoutRx,
     ) -> Result<RxSyncStream<&Self, T, BladeRf2>> {
         // TODO: Decide Ordering

--- a/src/streamers/mod.rs
+++ b/src/streamers/mod.rs
@@ -10,14 +10,14 @@ mod tx_sync_stream;
 pub use tx_sync_stream::*;
 
 #[derive(Debug, Clone, Copy)]
-pub struct SyncConfig {
+pub struct StreamConfig {
     pub(crate) num_buffers: u32,
     pub(crate) buffer_size: u32,
     pub(crate) num_transfers: u32,
     pub(crate) stream_timeout: u32,
 }
 
-impl SyncConfig {
+impl StreamConfig {
     pub fn new(
         num_buffers: u32,
         buffer_size: usize,
@@ -52,7 +52,7 @@ impl SyncConfig {
     }
 }
 
-impl Default for SyncConfig {
+impl Default for StreamConfig {
     /// Values taken from <https://www.nuand.com/libbladeRF-doc/v2.5.0/sync_no_meta.html>
     fn default() -> Self {
         Self {

--- a/src/streamers/rx_sync_stream.rs
+++ b/src/streamers/rx_sync_stream.rs
@@ -15,12 +15,12 @@ use crate::Result;
 use crate::RxChannel;
 use crate::SampleFormat;
 
-use super::SyncConfig;
+use super::StreamConfig;
 
 pub struct RxSyncStream<T: Borrow<D>, F: SampleFormat, D: BladeRF> {
     pub(crate) dev: T,
     pub(crate) layout: ChannelLayoutRx,
-    pub(crate) config: SyncConfig,
+    pub(crate) config: StreamConfig,
     pub(crate) _devtype: PhantomData<D>,
     pub(crate) _format: PhantomData<F>,
 }
@@ -44,7 +44,7 @@ impl<T: Borrow<D>, F: SampleFormat, D: BladeRF> RxSyncStream<T, F, D> {
     /// Need to ensure multiple streamers are not configured since a reconfiguration of one can change the sample type leading to our of bounds memory accesses.
     pub(crate) unsafe fn new(
         dev: T,
-        config: SyncConfig,
+        config: StreamConfig,
         layout: ChannelLayoutRx,
     ) -> Result<RxSyncStream<T, F, D>> {
         unsafe {
@@ -64,7 +64,7 @@ impl<T: Borrow<D>, F: SampleFormat, D: BladeRF> RxSyncStream<T, F, D> {
 impl<'a, F: SampleFormat, D: BladeRF> RxSyncStream<&'a D, F, D> {
     fn reconfigure_inner<NF: SampleFormat>(
         self,
-        config: SyncConfig,
+        config: StreamConfig,
         layout: ChannelLayoutRx,
     ) -> Result<RxSyncStream<&'a D, NF, D>> {
         let dev = self.dev;
@@ -79,7 +79,7 @@ impl<'a, F: SampleFormat, D: BladeRF> RxSyncStream<&'a D, F, D> {
 impl<F: SampleFormat, D: BladeRF> RxSyncStream<Arc<D>, F, D> {
     fn reconfigure_inner<NF: SampleFormat>(
         self,
-        config: SyncConfig,
+        config: StreamConfig,
         layout: ChannelLayoutRx,
     ) -> Result<RxSyncStream<Arc<D>, NF, D>> {
         let dev = self.dev.clone();
@@ -121,7 +121,7 @@ impl<T: Borrow<BladeRf1> + Clone, F: SampleFormat> RxSyncStream<T, F, BladeRf1> 
 impl<'a, F: SampleFormat> RxSyncStream<&'a BladeRf1, F, BladeRf1> {
     pub fn reconfigure<NF: SampleFormat>(
         self,
-        config: SyncConfig,
+        config: StreamConfig,
     ) -> Result<RxSyncStream<&'a BladeRf1, NF, BladeRf1>> {
         self.reconfigure_inner(config, ChannelLayoutRx::SISO(RxChannel::Rx0))
     }
@@ -130,7 +130,7 @@ impl<'a, F: SampleFormat> RxSyncStream<&'a BladeRf1, F, BladeRf1> {
 impl<F: SampleFormat> RxSyncStream<Arc<BladeRf1>, F, BladeRf1> {
     pub fn reconfigure<NF: SampleFormat>(
         self,
-        config: SyncConfig,
+        config: StreamConfig,
     ) -> Result<RxSyncStream<Arc<BladeRf1>, NF, BladeRf1>> {
         self.reconfigure_inner(config, ChannelLayoutRx::SISO(RxChannel::Rx0))
     }
@@ -173,7 +173,7 @@ impl<T: Borrow<BladeRf2> + Clone, F: SampleFormat> RxSyncStream<T, F, BladeRf2> 
 impl<'a, F: SampleFormat> RxSyncStream<&'a BladeRf2, F, BladeRf2> {
     pub fn reconfigure<NF: SampleFormat>(
         self,
-        config: SyncConfig,
+        config: StreamConfig,
         layout: ChannelLayoutRx,
     ) -> Result<RxSyncStream<&'a BladeRf2, NF, BladeRf2>> {
         self.reconfigure_inner(config, layout)
@@ -183,7 +183,7 @@ impl<'a, F: SampleFormat> RxSyncStream<&'a BladeRf2, F, BladeRf2> {
 impl<F: SampleFormat> RxSyncStream<Arc<BladeRf2>, F, BladeRf2> {
     pub fn reconfigure<NF: SampleFormat>(
         self,
-        config: SyncConfig,
+        config: StreamConfig,
         layout: ChannelLayoutRx,
     ) -> Result<RxSyncStream<Arc<BladeRf2>, NF, BladeRf2>> {
         self.reconfigure_inner(config, layout)
@@ -226,7 +226,7 @@ impl<T: Borrow<BladeRfAny> + Clone, F: SampleFormat> RxSyncStream<T, F, BladeRfA
 impl<'a, F: SampleFormat> RxSyncStream<&'a BladeRfAny, F, BladeRfAny> {
     pub fn reconfigure<NF: SampleFormat>(
         self,
-        config: SyncConfig,
+        config: StreamConfig,
         layout: ChannelLayoutRx,
     ) -> Result<RxSyncStream<&'a BladeRfAny, NF, BladeRfAny>> {
         self.reconfigure_inner(config, layout)
@@ -236,7 +236,7 @@ impl<'a, F: SampleFormat> RxSyncStream<&'a BladeRfAny, F, BladeRfAny> {
 impl<F: SampleFormat> RxSyncStream<Arc<BladeRfAny>, F, BladeRfAny> {
     pub fn reconfigure<NF: SampleFormat>(
         self,
-        config: SyncConfig,
+        config: StreamConfig,
         layout: ChannelLayoutRx,
     ) -> Result<RxSyncStream<Arc<BladeRfAny>, NF, BladeRfAny>> {
         self.reconfigure_inner(config, layout)

--- a/src/streamers/tx_sync_stream.rs
+++ b/src/streamers/tx_sync_stream.rs
@@ -15,12 +15,12 @@ use crate::Result;
 use crate::SampleFormat;
 use crate::TxChannel;
 
-use super::SyncConfig;
+use super::StreamConfig;
 
 pub struct TxSyncStream<T: Borrow<D>, F: SampleFormat, D: BladeRF> {
     pub(crate) dev: T,
     pub(crate) layout: ChannelLayoutTx,
-    pub(crate) config: SyncConfig,
+    pub(crate) config: StreamConfig,
     pub(crate) _devtype: PhantomData<D>,
     pub(crate) _format: PhantomData<F>,
 }
@@ -44,7 +44,7 @@ impl<T: Borrow<D>, F: SampleFormat, D: BladeRF> TxSyncStream<T, F, D> {
     /// Need to ensure multiple streamers are not configured since a reconfiguration of one can change the sample type leading to our of bounds memory accesses.
     pub(crate) unsafe fn new(
         dev: T,
-        config: SyncConfig,
+        config: StreamConfig,
         layout: ChannelLayoutTx,
     ) -> Result<TxSyncStream<T, F, D>> {
         unsafe {
@@ -64,7 +64,7 @@ impl<T: Borrow<D>, F: SampleFormat, D: BladeRF> TxSyncStream<T, F, D> {
 impl<'a, F: SampleFormat, D: BladeRF> TxSyncStream<&'a D, F, D> {
     fn reconfigure_inner<NF: SampleFormat>(
         self,
-        config: SyncConfig,
+        config: StreamConfig,
         layout: ChannelLayoutTx,
     ) -> Result<TxSyncStream<&'a D, NF, D>> {
         // Safety: the previous streamer is moved, and is dropped so we are save to construct a new one.
@@ -75,7 +75,7 @@ impl<'a, F: SampleFormat, D: BladeRF> TxSyncStream<&'a D, F, D> {
 impl<F: SampleFormat, D: BladeRF> TxSyncStream<Arc<D>, F, D> {
     fn reconfigure_inner<NF: SampleFormat>(
         self,
-        config: SyncConfig,
+        config: StreamConfig,
         layout: ChannelLayoutTx,
     ) -> Result<TxSyncStream<Arc<D>, NF, D>> {
         // Safety: the previous streamer is moved, and is dropped so we are save to construct a new one.
@@ -113,7 +113,7 @@ impl<T: Borrow<BladeRf1>, F: SampleFormat> TxSyncStream<T, F, BladeRf1> {
 impl<'a, F: SampleFormat> TxSyncStream<&'a BladeRf1, F, BladeRf1> {
     pub fn reconfigure<NF: SampleFormat>(
         self,
-        config: SyncConfig,
+        config: StreamConfig,
     ) -> Result<TxSyncStream<&'a BladeRf1, NF, BladeRf1>> {
         self.reconfigure_inner(config, ChannelLayoutTx::SISO(TxChannel::Tx0))
     }
@@ -122,7 +122,7 @@ impl<'a, F: SampleFormat> TxSyncStream<&'a BladeRf1, F, BladeRf1> {
 impl<F: SampleFormat> TxSyncStream<Arc<BladeRf1>, F, BladeRf1> {
     pub fn reconfigure<NF: SampleFormat>(
         self,
-        config: SyncConfig,
+        config: StreamConfig,
     ) -> Result<TxSyncStream<Arc<BladeRf1>, NF, BladeRf1>> {
         self.reconfigure_inner(config, ChannelLayoutTx::SISO(TxChannel::Tx0))
     }
@@ -164,7 +164,7 @@ impl<T: Borrow<BladeRf2> + Clone, F: SampleFormat> TxSyncStream<T, F, BladeRf2> 
 impl<'a, F: SampleFormat> TxSyncStream<&'a BladeRf2, F, BladeRf2> {
     pub fn reconfigure<NF: SampleFormat>(
         self,
-        config: SyncConfig,
+        config: StreamConfig,
         layout: ChannelLayoutTx,
     ) -> Result<TxSyncStream<&'a BladeRf2, NF, BladeRf2>> {
         self.reconfigure_inner(config, layout)
@@ -174,7 +174,7 @@ impl<'a, F: SampleFormat> TxSyncStream<&'a BladeRf2, F, BladeRf2> {
 impl<F: SampleFormat> TxSyncStream<Arc<BladeRf2>, F, BladeRf2> {
     pub fn reconfigure<NF: SampleFormat>(
         self,
-        config: SyncConfig,
+        config: StreamConfig,
         layout: ChannelLayoutTx,
     ) -> Result<TxSyncStream<Arc<BladeRf2>, NF, BladeRf2>> {
         self.reconfigure_inner(config, layout)
@@ -217,7 +217,7 @@ impl<T: Borrow<BladeRfAny> + Clone, F: SampleFormat> TxSyncStream<T, F, BladeRfA
 impl<'a, F: SampleFormat> TxSyncStream<&'a BladeRfAny, F, BladeRfAny> {
     pub fn reconfigure<NF: SampleFormat>(
         self,
-        config: SyncConfig,
+        config: StreamConfig,
         layout: ChannelLayoutTx,
     ) -> Result<TxSyncStream<&'a BladeRfAny, NF, BladeRfAny>> {
         self.reconfigure_inner(config, layout)
@@ -227,7 +227,7 @@ impl<'a, F: SampleFormat> TxSyncStream<&'a BladeRfAny, F, BladeRfAny> {
 impl<F: SampleFormat> TxSyncStream<Arc<BladeRfAny>, F, BladeRfAny> {
     pub fn reconfigure<NF: SampleFormat>(
         self,
-        config: SyncConfig,
+        config: StreamConfig,
         layout: ChannelLayoutTx,
     ) -> Result<TxSyncStream<Arc<BladeRfAny>, NF, BladeRfAny>> {
         self.reconfigure_inner(config, layout)

--- a/tests/hardware_any.rs
+++ b/tests/hardware_any.rs
@@ -4,7 +4,7 @@ use std::{thread, time::Duration};
 
 use bladerf::{
     BladeRF, BladeRfAny, ChannelLayoutRx, ComplexI12, ComplexI16, Error, Result, RxChannel,
-    SyncConfig,
+    StreamConfig,
 };
 use serial_test::serial;
 
@@ -212,8 +212,10 @@ fn get_board_name() -> Result<()> {
 #[serial]
 fn rx_streamer_toggle_enabled() -> Result<()> {
     let device = BladeRfAny::open_first()?;
-    let rx_streamer = device
-        .rx_streamer::<ComplexI16>(SyncConfig::default(), ChannelLayoutRx::SISO(RxChannel::Rx0))?;
+    let rx_streamer = device.rx_streamer::<ComplexI16>(
+        StreamConfig::default(),
+        ChannelLayoutRx::SISO(RxChannel::Rx0),
+    )?;
 
     // Make sure that we can enable, disable and reenable again as well as read some samples.
     rx_streamer.enable()?;
@@ -229,13 +231,17 @@ fn rx_streamer_toggle_enabled() -> Result<()> {
 #[serial]
 fn rx_streamer_reconfigure() -> Result<()> {
     let device = BladeRfAny::open_first()?;
-    let rx_streamer = device
-        .rx_streamer::<ComplexI16>(SyncConfig::default(), ChannelLayoutRx::SISO(RxChannel::Rx0))?;
+    let rx_streamer = device.rx_streamer::<ComplexI16>(
+        StreamConfig::default(),
+        ChannelLayoutRx::SISO(RxChannel::Rx0),
+    )?;
 
     rx_streamer.enable()?;
 
-    let new_rxstreamer = rx_streamer
-        .reconfigure::<ComplexI12>(SyncConfig::default(), ChannelLayoutRx::SISO(RxChannel::Rx0))?;
+    let new_rxstreamer = rx_streamer.reconfigure::<ComplexI12>(
+        StreamConfig::default(),
+        ChannelLayoutRx::SISO(RxChannel::Rx0),
+    )?;
 
     new_rxstreamer.enable()?;
     new_rxstreamer.disable()?;


### PR DESCRIPTION
Rename SyncConfig to StreamConfig since it is not actually specific o synchronous streams.

This also brings up that point that since the stream_timeout parameter is only specific to the sync streams,
we should probably remove it from the struct and have it passed in to calls to `BladeRF:rx_streamer()` and `tx_streamer()`

Those functions also probably be renames to something like `rx_sync_streamer()`

Let me know what you think.