### PR TITLE
Expansion board functions part of BladeRF trait

### DIFF
--- a/src/bladerf.rs
+++ b/src/bladerf.rs
@@ -1291,6 +1291,30 @@ pub trait BladeRF: Sized + Drop {
         name_raw.to_str().unwrap()
     }
 
+    /// Attempt to attach/connect to the given expansion module to use its features.
+    ///
+    /// In general this should not be used by users of this library as it is intended for intenal use only.
+    ///
+    /// Related `libbladerf` docs: <https://www.nuand.com/libbladeRF-doc/v2.5.0/group___f_n___x_b.html#ga9fb4c2d62dcdc2f05b23098a35beacc5>
+    #[doc(hidden)]
+    fn expansion_attach(&self, module: ExpansionModule) -> Result<()> {
+        let res = unsafe { bladerf_expansion_attach(self.get_device_ptr(), module as bladerf_xb) };
+        check_res!(res);
+        Ok(())
+    }
+
+    /// Determine which expansion board is attached.
+    ///
+    /// See also the [expansion boards][crate::expansion_boards] module documentation.
+    ///
+    /// Related `libbladerf` docs: <https://www.nuand.com/libbladeRF-doc/v2.5.0/group___f_n___x_b.html#gac9d4f9e8727ab2ffe8925495bc895ada>
+    fn get_attached_expansion(&self) -> Result<ExpansionModule> {
+        let mut module = bladerf_xb_BLADERF_XB_NONE;
+        let res = unsafe { bladerf_expansion_get_attached(self.get_device_ptr(), &mut module) };
+        check_res!(res);
+        ExpansionModule::try_from(module)
+    }
+
     /// # Safety
     /// Intended for internal use.
     ///

--- a/src/bladerf1.rs
+++ b/src/bladerf1.rs
@@ -258,21 +258,6 @@ impl BladeRf1 {
         unsafe { RxSyncStream::new(device, config, ChannelLayoutRx::SISO(RxChannel::Rx0)) }
     }
 
-    // TODO move to BladeRF trait
-    fn expansion_attach(&self, module: ExpansionModule) -> Result<()> {
-        let res = unsafe { bladerf_expansion_attach(self.device, module as bladerf_xb) };
-        check_res!(res);
-        Ok(())
-    }
-
-    // TODO move to BladeRF trait
-    pub fn get_attached_expansion(&self) -> Result<ExpansionModule> {
-        let mut module = bladerf_xb_BLADERF_XB_NONE;
-        let res = unsafe { bladerf_expansion_get_attached(self.device, &mut module) };
-        check_res!(res);
-        ExpansionModule::try_from(module)
-    }
-
     /// Gets the [Xb200] struct allowing for control of the XB200 transverter board
     pub fn get_xb200(&self) -> Result<Xb200> {
         self.expansion_attach(ExpansionModule::Xb200)?;

--- a/src/types/expansion_module.rs
+++ b/src/types/expansion_module.rs
@@ -6,7 +6,7 @@ use crate::{sys::*, Error, Result};
 
 /// Represents the different expansion boards.
 ///
-/// This is specifically for when querying what expansion board is attached with [BladeRf1::get_attached_expansion()][crate::BladeRf1::get_attached_expansion()]
+/// This is specifically for when querying what expansion board is attached with [BladeRf1::get_attached_expansion()][crate::BladeRF::get_attached_expansion()]
 ///
 /// Relevant `libbladerf` docs: <https://www.nuand.com/libbladeRF-doc/v2.5.0/group___f_n___x_b.html#gaf5376b7092ea9750302429c2613529e7>
 #[derive(Copy, Clone, Debug, FromRepr, PartialEq, Eq)]


### PR DESCRIPTION
The expansion functions are now part of the BladeRF trait.

I originally had it in the bladerf1 specific functions beaucse I did not realise the bladerf2 supported expansion modules: at present, nuand only sells modules for the bladerf1.